### PR TITLE
Embed images in SVG output

### DIFF
--- a/src/wireviz/svgembed.py
+++ b/src/wireviz/svgembed.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+import base64
+import re
+from pathlib import Path
+from typing import Union
+
+mime_subtype_replacements = {"jpg": "jpeg", "tif": "tiff"}
+
+
+def embed_svg_images(svg_in: str, base_path: Union[str, Path] = Path.cwd()) -> str:
+    images_b64 = {}  # cache of base64-encoded images
+
+    def image_tag(pre: str, url: str, post: str) -> str:
+        return f'<image{pre} xlink:href="{url}"{post}>'
+
+    def replace(match: re.Match) -> str:
+        imgurl = match["URL"]
+        if not imgurl in images_b64:  # only encode/cache every unique URL once
+            imgurl_abs = (Path(base_path) / imgurl).resolve()
+            image = imgurl_abs.read_bytes()
+            images_b64[imgurl] = base64.b64encode(image).decode("utf-8")
+        return image_tag(
+            match["PRE"] or "",
+            f"data:image/{get_mime_subtype(imgurl)};base64, {images_b64[imgurl]}",
+            match["POST"] or "",
+        )
+
+    pattern = re.compile(
+        image_tag(r"(?P<PRE> [^>]*?)?", r'(?P<URL>[^"]*?)', r"(?P<POST> [^>]*?)?"),
+        re.IGNORECASE,
+    )
+    return pattern.sub(replace, svg_in)
+
+
+def get_mime_subtype(filename: Union[str, Path]) -> str:
+    mime_subtype = Path(filename).suffix.lstrip(".").lower()
+    if mime_subtype in mime_subtype_replacements:
+        mime_subtype = mime_subtype_replacements[mime_subtype]
+    return mime_subtype
+
+
+def embed_svg_images_file(
+    filename_in: Union[str, Path], overwrite: bool = True
+) -> None:
+    filename_in = Path(filename_in).resolve()
+    filename_out = filename_in.with_suffix(".b64.svg")
+    filename_out.write_text(
+        embed_svg_images(filename_in.read_text(), filename_in.parent)
+    )
+    if overwrite:
+        filename_out.replace(filename_in)

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -37,7 +37,7 @@ def generate_html_output(
     html = open_file_read(templatefile).read()
 
     # embed SVG diagram
-    with open_file_read(f"{filename}.svg") as file:
+    with open_file_read(f"{filename}.tmp.svg") as file:
         svgdata = re.sub(
             "^<[?]xml [^?>]*[?]>[^<]*<!DOCTYPE [^>]*>",
             "<!-- XML and DOCTYPE declarations from SVG file removed -->",


### PR DESCRIPTION
[Update 2020-11-16]

This PR has evolved from simply fixing how relative image paths are resolved, to embedding any images in the SVG file by default, eliminating the original issue.

---

Previously, paths to images were resolved relatively to the specified _output_ file instead of the _input_ file.

This produces errors when calling WireViz with the `-o` flag, creating output files in a different location from the input.

This PR [partially, see comment below] fixes the problem.

Additionally, it eliminates the need for passing a `gv_dir` variable to the `Image` class, resolving paths beforehand and passing the absolute path to the `Image` class.