### PR TITLE
Add unpopulated option to additional components qty multiplier

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -408,6 +408,7 @@ Parts can be added to a connector or cable in the section `<additional-component
                   # when used in a connector:
                   # pincount         number of pins of connector
                   # populated        number of populated positions in a connector
+                  # unpopulated      number of unpopulated positions
                   # when used in a cable:
                   # wirecount        number of wires of cable/bundle
                   # terminations     number of terminations on a cable/bundle

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -18,7 +18,7 @@ MultilineHypertext = (
 Designator = PlainText  # Case insensitive unique name of connector or cable
 
 # Literal type aliases below are commented to avoid requiring python 3.8
-ConnectorMultiplier = PlainText  # = Literal['pincount', 'populated']
+ConnectorMultiplier = PlainText  # = Literal['pincount', 'populated', 'unpopulated']
 CableMultiplier = (
     PlainText  # = Literal['wirecount', 'terminations', 'length', 'total_length']
 )
@@ -232,6 +232,8 @@ class Connector:
             return self.pincount
         elif qty_multiplier == "populated":
             return sum(self.visible_pins.values())
+        elif qty_multiplier == 'unpopulated':
+            return (self.pincount - sum(self.visible_pins.values()))
         else:
             raise ValueError(
                 f"invalid qty multiplier parameter for connector {qty_multiplier}"

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -233,7 +233,7 @@ class Connector:
         elif qty_multiplier == "populated":
             return sum(self.visible_pins.values())
         elif qty_multiplier == 'unpopulated':
-            return (self.pincount - sum(self.visible_pins.values()))
+            return max(0, self.pincount - sum(self.visible_pins.values()))
         else:
             raise ValueError(
                 f"invalid qty multiplier parameter for connector {qty_multiplier}"

--- a/src/wireviz/wv_bom.py
+++ b/src/wireviz/wv_bom.py
@@ -35,7 +35,8 @@ def get_additional_component_table(
     rows = []
     if component.additional_components:
         rows.append(["Additional components"])
-        for part in component.additional_components:
+        # Ignore components that have qty 0
+        for part in [part for part in component.additional_components if component.get_qty_multiplier(part.qty_multiplier)]:
             common_args = {
                 "qty": part.qty * component.get_qty_multiplier(part.qty_multiplier),
                 "unit": part.unit,
@@ -63,7 +64,8 @@ def get_additional_component_table(
 def get_additional_component_bom(component: Union[Connector, Cable]) -> List[BOMEntry]:
     """Return a list of BOM entries with additional components."""
     bom_entries = []
-    for part in component.additional_components:
+    # Ignore components that have qty 0
+    for part in [part for part in component.additional_components if component.get_qty_multiplier(part.qty_multiplier)]:
         bom_entries.append(
             {
                 "description": part.description,


### PR DESCRIPTION
qty_multiplier can be set to `unpopulated` when defining additional connector components. This will calculate the number of empty pin spaces in the connector.

I use this for waterproof connectors which require sealing plugs to be installed in unoccupied sockets.