### PR TITLE
Use portable OS error codes so program doesn't crash

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -390,7 +390,7 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if no FileNotFoundError exception happens, get file contents
             yaml_str = open_file_read(yaml_path).read()
         except (FileNotFoundError, OSError) as e:
-            # if inp is a long YAML string, Pathlib will raise OSError: [Errno 63]
+            # if inp is a long YAML string, Pathlib will raise OSError: [errno.ENAMETOOLONG]
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
             from errno import ENAMETOOLONG

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -393,7 +393,8 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if inp is a long YAML string, Pathlib will raise OSError: [Errno 63]
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
-            if type(e) is OSError and e.errno != 36 and e.errno != 22:
+            from errno import ENAMETOOLONG
+            if type(e) is OSError and e.errno != ENAMETOOLONG:
                 raise e
             # file does not exist; assume inp is a YAML string
             yaml_str = inp

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -393,7 +393,7 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if inp is a long YAML string, Pathlib will raise OSError: [Errno 63]
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
-            if type(e) is OSError and e.errno != 63:
+            if type(e) is OSError and e.errno != 36:
                 raise e
             # file does not exist; assume inp is a YAML string
             yaml_str = inp

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -393,7 +393,8 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if inp is a long YAML string, Pathlib will raise OSError: [Errno 63]
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
-            if type(e) is OSError and e.errno != 36:
+            print(e.errno)
+            if type(e) is OSError and e.errno != 36 and e.errno != 22:
                 raise e
             # file does not exist; assume inp is a YAML string
             yaml_str = inp

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -393,7 +393,6 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if inp is a long YAML string, Pathlib will raise OSError: [Errno 63]
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
-            print(e.errno)
             if type(e) is OSError and e.errno != 36 and e.errno != 22:
                 raise e
             # file does not exist; assume inp is a YAML string


### PR DESCRIPTION
I think OSError had an update at some point, and the error code the program looks for changed. Anyhow this change fixes the titleblock-added version of the program. 