### PR TITLE
Handle OSError [errno.EINVAL] that might be raised in Windows

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -408,11 +408,12 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             yaml_str = open_file_read(yaml_path).read()
         except (FileNotFoundError, OSError) as e:
             # if inp is a long YAML string, Pathlib will raise OSError: [errno.ENAMETOOLONG]
+            # (in Windows, it seems OSError [errno.EINVAL] might be raised in some cases)
             # when trying to expand and resolve it as a path.
             # Catch this error, but raise any others
-            from errno import ENAMETOOLONG
+            from errno import EINVAL, ENAMETOOLONG
 
-            if type(e) is OSError and e.errno != ENAMETOOLONG:
+            if type(e) is OSError and e.errno not in (EINVAL, ENAMETOOLONG):
                 raise e
             # file does not exist; assume inp is a YAML string
             yaml_str = inp


### PR DESCRIPTION
Suggested fix posted in
https://github.com/wireviz/WireViz/issues/344#issuecomment-2113476151

Please verify that this fixes #344 and report back.

~~The base branch of this PR is `master` for the time beeing, but it should be changed to a new release/v0.4.1-rc before any merge-in. #345 should also be fixed and updating the changelog before releasing the hotfix.~~