### PR TITLE
Add template files to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     keywords="cable connector hardware harness wiring wiring-diagram wiring-harness",
     url=APP_URL,
     package_dir={"": "src"},
+    package_data={CMD_NAME: ["templates/*.html"]},
     packages=find_packages("src"),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Specify all HTML files under templates folder to be included as package data files.

Is this sufficient to fix #345? Some sources claim that `include_package_data=True` also is needed, but preliminary testing at my Windows setup seems to prove otherwise. I would prefer that some others could confirm at different platforms and versions.

Please, anyone, test this branch at the platform(s) you have access to, and report back here the output from all commands. See the simple installation command in https://github.com/wireviz/WireViz/pull/347#issuecomment-2152259121 below.

Alternatively, a longer and more complicated test procedure is suggested a bit earlier below, and if you don't have `git` installed, you can replace the `git clone` command with unpacking all files from [this ZIP-file](https://github.com/wireviz/WireViz/archive/refs/heads/fix345.zip) into a new subfolder you call `WireViz` using your favorite unzip tool. The subfolder is called `WireViz-fix345` inside the ZIP-file, but you can rename it after unpacking.

- [ ] Verified at Windows
- [x] Verified at Linux
- [ ] Verified at macOS