### PR TITLE
Fix bugs in mate processing

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -595,6 +595,7 @@ class Harness:
                 typecheck("tweak.append", self.tweak.append, str)
                 dot.body.append(self.tweak.append)
 
+        # TODO: All code below until "return dot" must be moved above all tweak processing!
         for mate in self.mates:
             if mate.shape[0] == "<" and mate.shape[-1] == ">":
                 dir = "both"
@@ -613,29 +614,18 @@ class Harness:
                 raise Exception(f"{mate} is an unknown mate")
 
             from_connector = self.connectors[mate.from_name]
-            if (
-                isinstance(mate, MatePin)
-                and self.connectors[mate.from_name].style != "simple"
-            ):
+            to_connector = self.connectors[mate.to_name]
+            if isinstance(mate, MatePin) and from_connector.style != "simple":
                 from_pin_index = from_connector.pins.index(mate.from_pin)
                 from_port_str = f":p{from_pin_index+1}r"
             else:  # MateComponent or style == 'simple'
                 from_port_str = ""
-            if (
-                isinstance(mate, MatePin)
-                and self.connectors[mate.to_name].style != "simple"
-            ):
+            if isinstance(mate, MatePin) and to_connector.style != "simple":
                 to_pin_index = to_connector.pins.index(mate.to_pin)
-                to_port_str = (
-                    f":p{to_pin_index+1}l"
-                    if isinstance(mate, MatePin)
-                    and self.connectors[mate.to_name].style != "simple"
-                    else ""
-                )
+                to_port_str = f":p{to_pin_index+1}l"
             else:  # MateComponent or style == 'simple'
                 to_port_str = ""
             code_from = f"{mate.from_name}{from_port_str}:e"
-            to_connector = self.connectors[mate.to_name]
             code_to = f"{mate.to_name}{to_port_str}:w"
 
             dot.attr("edge", color=color, style="dashed", dir=dir)


### PR DESCRIPTION
The code processing mates used a mix of repeated connector look-ups and local connector variables, and one variable was used before it was assigned the correct value.

This error was detected when investigating the #355 bug report.

- [x] The local connector variables are now both assigned initially when processing each mate, and used instead of repeated connector look-ups.
- [x] The same code section also had an unfortunate side-effect - observed in https://github.com/wireviz/WireViz/issues/325#issuecomment-2116395221
that caused some generated dot output to be unavailable for tweaking. A fix for that is now pushed as a separate commit into this PR.