### PR TITLE
Use output_name as default title

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -20,6 +20,8 @@ from wireviz.wv_helper import (
     smart_file_resolve,
 )
 
+from . import APP_NAME
+
 
 def parse(
     inp: Union[Path, str, Dict],
@@ -117,10 +119,7 @@ def parse(
 
     # When title is not given, either deduce it from filename, or use default text.
     if "title" not in harness.metadata:
-        if yaml_file is None:
-            harness.metadata["title"] = "WireViz diagram and BOM"
-        else:
-            harness.metadata["title"] = Path(yaml_file).stem
+        harness.metadata["title"] = output_name or f"{APP_NAME} diagram and BOM"
 
     # add items
     # parse YAML input file ====================================================


### PR DESCRIPTION
The CLI handling code was redesigned for v0.4 and it seems the code to assign a default title from v0.3.1 has been messed up. This bug has not been triggered by `build_examples.py` due to it seems to call the `parse()` function differently.

The `output_name` should be used as default title when present.

This will fix the #360 bug report.