### PR TITLE
[Bug] add missing import of embed_svg_images

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -20,7 +20,7 @@ from wireviz.DataClasses import (
     Tweak,
     Side,
 )
-from wireviz.svgembed import embed_svg_images_file
+from wireviz.svgembed import embed_svg_images_file, embed_svg_images
 from wireviz.wv_bom import (
     HEADER_MPN,
     HEADER_PN,

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -20,7 +20,7 @@ from wireviz.DataClasses import (
     Tweak,
     Side,
 )
-from wireviz.svgembed import embed_svg_images_file, embed_svg_images
+from wireviz.svgembed import embed_svg_images, embed_svg_images_file
 from wireviz.wv_bom import (
     HEADER_MPN,
     HEADER_PN,


### PR DESCRIPTION
Harness.py uses embed_svg_images without importing it first.

Edit:
wireviz 0.4
python 3.11.9
dot - graphviz version 11.0.0 (20240428.1522)

It occurs as issue if you embed wireviz in a python script

e.g.:
```python
from wireviz.wireviz import parse

y = """---
connectors:
  X1:
    type: D-Sub
    subtype: female
    pinlabels: [DCD, RX, TX, DTR, GND, DSR, RTS, CTS, RI]
  X2:
    type: Molex KK 254
    subtype: female
    pinlabels: [GND, RX, TX]

cables:
  W1:
    gauge: 0.25 mm2
    length: 0.2
    color_code: DIN
    wirecount: 3
    shield: true

connections:
  -
    - X1: [5,2,3]
    - W1: [1,2,3]
    - X2: [1,3,2]
  -
    - X1: 5
    - W1: s
"""
```

```python
parse(y, return_types="svg", output_name="test.svg")
Traceback (most recent call last):
  File "C:\Users\adaemmer\git\test\wireviz_demo.py", line 32, in <module>
    parse(y, return_types="svg", output_name="test.svg")
  File "C:\Users\adaemmer\.virtualenvs\test\Lib\site-packages\wireviz\wireviz.py", line 395, in parse
    returns.append(harness.svg)
                   ^^^^^^^^^^^
  File "C:\Users\adaemmer\.virtualenvs\test\Lib\site-packages\wireviz\Harness.py", line 669, in svg
    return embed_svg_images(graph.pipe(format="svg").decode("utf-8"), Path.cwd())
           ^^^^^^^^^^^^^^^^
NameError: name 'embed_svg_images' is not defined. Did you mean: 'embed_svg_images_file'?
```