### PR TITLE
Add HTML template placeholders for filename

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -353,6 +353,7 @@ If any component is defined in the `connectors` or `cables` sections but not ref
   # If no value is specified for 'title', then the
   # output filename without extension is used.
 ```
+See [HTML Output Templates](../src/wireviz/templates/) for how metadata entries can be inserted into the HTML output.
 
 ## Options
 

--- a/src/wireviz/svgembed.py
+++ b/src/wireviz/svgembed.py
@@ -8,6 +8,20 @@ from typing import Union
 mime_subtype_replacements = {"jpg": "jpeg", "tif": "tiff"}
 
 
+# TODO: Share cache and code between data_URI_base64() and embed_svg_images()
+def data_URI_base64(file: Union[str, Path], media: str = "image") -> str:
+    """Return Base64-encoded data URI of input file."""
+    file = Path(file)
+    b64 = base64.b64encode(file.read_bytes()).decode("utf-8")
+    uri = f"data:{media}/{get_mime_subtype(file)};base64, {b64}"
+    # print(f"data_URI_base64('{file}', '{media}') -> {len(uri)}-character URI")
+    if len(uri) > 65535:
+        print(
+            "data_URI_base64(): Warning: Browsers might have different URI length limitations"
+        )
+    return uri
+
+
 def embed_svg_images(svg_in: str, base_path: Union[str, Path] = Path.cwd()) -> str:
     images_b64 = {}  # cache of base64-encoded images
 

--- a/src/wireviz/templates/README.md
+++ b/src/wireviz/templates/README.md
@@ -1,0 +1,51 @@
+# HTML Output Templates
+
+This is the standard folder where WireViz looks for an HTML output template file.
+
+## Which HTML Output Template File is Used?
+
+A named HTML output template can optionally be specified as
+`metadata.template.name` in the YAML input:
+```yaml
+metadata:
+  template:
+    name: din-6771
+```
+In the case above, WireViz will search for a template file named
+`din-6771.html` in these folders:
+1. In the same folder as the YAML input file.
+2. In this standard template folder.
+
+If no HTML output template is specified, the `simple` template is assumed
+(i.e. filename `simple.html`, and in this case,
+only the standard template folder is searched).
+
+## Placeholders in HTML Output Templates
+
+HTML output template files might contain placeholders that will be replaced by
+generated text by WireViz when producing HTML output based on such a template.
+A placeholder starts with `<!-- %`, followed by a keyword, and finally `% -->`.
+Note that there must be one single space between `--` and `%` at both ends.
+
+| Placeholder | Replaced by |
+| --- | --- |
+| `<!-- %generator% -->` | The application name, version, and URL |
+| `<!-- %fontname% -->`  | The value of `options.fontname` |
+| `<!-- %bgcolor% -->`   | The HEX color translation of `options.bgcolor` |
+| `<!-- %filename% -->`  | The output path and filename without extension |
+| `<!-- %filename_stem% -->` | The output filename without path nor extension |
+| `<!-- %bom% -->`           | BOM as HTML table with headers at top |
+| `<!-- %bom_reversed% -->`  | Reversed BOM as HTML table with headers at bottom |
+| `<!-- %sheet_current% -->` | `1` (multi-page documents not yet supported) |
+| `<!-- %sheet_total% -->`   | `1` (multi-page documents not yet supported) |
+| `<!-- %diagram% -->`       | Embedded SVG diagram as valid HTML |
+| `<!-- %diagram_png_base64% -->` | Embedded base64 encoded PNG diagram as URI |
+| `<!-- %{item}% -->`             | String or numeric value of `metadata.{item}` |
+| `<!-- %{item}_{i}% -->`         | Category number `{i}` within dict value of `metadata.{item}` |
+| `<!-- %{item}_{i}_{key}% -->`   | Value of `metadata.{item}.{category}.{key}` |
+
+Note that `{item}`, `{category}` and `{key}` in the description above can be
+any valid YAML key, and `{i}` is an integer representing the 1-based index of
+category entries in a dict `metadata.{item}` entry.
+The `{` and `}` characters are not literally part of the syntax, just used in
+this documentation to enclose the variable parts of the keywords.

--- a/src/wireviz/templates/README.md
+++ b/src/wireviz/templates/README.md
@@ -39,10 +39,10 @@ Note that there must be one single space between `--` and `%` at both ends.
 | `<!-- %sheet_current% -->` | `1` (multi-page documents not yet supported) |
 | `<!-- %sheet_total% -->`   | `1` (multi-page documents not yet supported) |
 | `<!-- %diagram% -->`       | Embedded SVG diagram as valid HTML |
-| `<!-- %diagram_png_base64% -->` | Embedded base64 encoded PNG diagram as URI |
-| `<!-- %{item}% -->`             | String or numeric value of `metadata.{item}` |
-| `<!-- %{item}_{i}% -->`         | Category number `{i}` within dict value of `metadata.{item}` |
-| `<!-- %{item}_{i}_{key}% -->`   | Value of `metadata.{item}.{category}.{key}` |
+| `<!-- %diagram_png_b64% -->`  | Embedded base64 encoded PNG diagram as URI |
+| `<!-- %{item}% -->`           | String or numeric value of `metadata.{item}` |
+| `<!-- %{item}_{i}% -->`       | Category number `{i}` within dict value of `metadata.{item}` |
+| `<!-- %{item}_{i}_{key}% -->` | Value of `metadata.{item}.{category}.{key}` |
 
 Note that `{item}`, `{category}` and `{key}` in the description above can be
 any valid YAML key, and `{i}` is an integer representing the 1-based index of

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -96,7 +96,7 @@ def generate_html_output(
 
     replacement_if_used("<!-- %diagram% -->", svgdata)
     replacement_if_used(
-        "<!-- %diagram_png_base64% -->", lambda: data_URI_base64(f"{filename}.png")
+        "<!-- %diagram_png_b64% -->", lambda: data_URI_base64(f"{filename}.png")
     )
 
     # prepare metadata replacements

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Union
 
 from wireviz import APP_NAME, APP_URL, __version__, wv_colors
 from wireviz.DataClasses import Metadata, Options
+from wireviz.svgembed import data_URI_base64
 from wireviz.wv_gv_html import html_line_breaks
 from wireviz.wv_helper import (
     flatten2d,
@@ -81,7 +82,7 @@ def generate_html_output(
         "<!-- %fontname% -->": options.fontname,
         "<!-- %bgcolor% -->": wv_colors.translate_color(options.bgcolor, "hex"),
         "<!-- %diagram% -->": svgdata,
-        # TODO: "<!-- %diagram_png_base64% -->": base64 of png file
+        "<!-- %diagram_png_base64% -->": data_URI_base64(f"{filename}.png"),
         "<!-- %filename% -->": str(filename),
         "<!-- %filename_stem% -->": Path(filename).stem,
         "<!-- %bom% -->": bom_html,

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -81,6 +81,9 @@ def generate_html_output(
         "<!-- %fontname% -->": options.fontname,
         "<!-- %bgcolor% -->": wv_colors.translate_color(options.bgcolor, "hex"),
         "<!-- %diagram% -->": svgdata,
+        # TODO: "<!-- %diagram_png_base64% -->": base64 of png file
+        "<!-- %filename% -->": str(filename),
+        "<!-- %filename_stem% -->": Path(filename).stem,
         "<!-- %bom% -->": bom_html,
         "<!-- %bom_reversed% -->": bom_html_reversed,
         "<!-- %sheet_current% -->": "1",  # TODO: handle multi-page documents


### PR DESCRIPTION
This will e.g. enable users to replace SVG diagram with PNG, that is needed as a work-around when the SVG output from Graphviz is not looking good. Suggested as work-around for Graphviz bug in https://github.com/wireviz/WireViz/issues/175#issuecomment-2132206026

- [x] `<!-- %filename% -->`
- [x] `<!-- %filename_stem% -->`
- [x] `<!-- %diagram_png_b64% -->`
- [x] The placeholders should be documented, maybe in a new `templates/README.md`.