### PR TITLE
Avoid decimal point and trailing zero for integer BOM quantities

### DIFF
--- a/src/wireviz/wv_bom.py
+++ b/src/wireviz/wv_bom.py
@@ -204,7 +204,7 @@ def generate_bom(harness: "Harness") -> List[BOMEntry]:
         bom.append(
             {
                 **group_entries[0],
-                "qty": round(total_qty, 3),
+                "qty": int(total_qty) if float(total_qty).is_integer() else round(total_qty, 3),
                 "designators": sorted(set(designators)),
             }
         )


### PR DESCRIPTION
Sometimes the total length of certain items in the BOM will be shown with a decimal point and a trailing zero even if all values are input as integers. One source of this is https://github.com/wireviz/WireViz/blob/v0.4/src/wireviz/DataClasses.py#L310 where an integer value will be converted to a float value, but there might be other places in the code that could cause the same issue.

This change will resolve the issue at the other end (while processing the BOM) - independently of what might be the source of the issue. This should fix #340.