### PR TITLE
Avoid Graphviz error when hiding all pins

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -253,6 +253,9 @@ class Harness:
 
                 pinhtml.append("  </table>")
 
+                if len(pinhtml) == 2:  # Table start and end with no rows between?
+                    pinhtml = ["<!-- all pins hidden -->"]  # Avoid Graphviz error
+
                 html = [
                     row.replace("<!-- connector table -->", "\n".join(pinhtml))
                     for row in html


### PR DESCRIPTION
This bug was reported in #257 more than 2.5 years ago, but is still present in v0.4, and can be triggered by e.g. this YAML input:
```yaml
connectors:
  X1:
    pincount: 2
    hide_disconnected_pins: true
connections:
 - - X1
```
Graphviz reports an error when the HTML table of pins is empty.

This minor change should fix #257