### PR TITLE
Rename placehoder "sheetsize_default" to <!-- %template_sheetsize% -->

### DIFF
--- a/src/wireviz/templates/README.md
+++ b/src/wireviz/templates/README.md
@@ -43,6 +43,7 @@ Note that there must be one single space between `--` and `%` at both ends.
 | `<!-- %{item}% -->`           | String or numeric value of `metadata.{item}` |
 | `<!-- %{item}_{i}% -->`       | Category number `{i}` within dict value of `metadata.{item}` |
 | `<!-- %{item}_{i}_{key}% -->` | Value of `metadata.{item}.{category}.{key}` |
+| `<!-- %template_sheetsize% -->` | Value of `metadata.template.sheetsize` |
 
 Note that `{item}`, `{category}` and `{key}` in the description above can be
 any valid YAML key, and `{i}` is an integer representing the 1-based index of

--- a/src/wireviz/templates/din-6771.html
+++ b/src/wireviz/templates/din-6771.html
@@ -179,7 +179,7 @@
 </head>
 <body>
   <div id="page">
-    <div id="frame" class="sheetsize_default">
+    <div id="frame" class="<!-- %template_sheetsize% -->">
 
       <div id="diagram">
 

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -87,6 +87,9 @@ def generate_html_output(
         "<!-- %bom_reversed% -->": bom_html_reversed,
         "<!-- %sheet_current% -->": "1",  # TODO: handle multi-page documents
         "<!-- %sheet_total% -->": "1",  # TODO: handle multi-page documents
+        "<!-- %template_sheetsize% -->": metadata.get("template", {}).get(
+            "sheetsize", ""
+        ),
     }
 
     def replacement_if_used(key: str, func: Callable[[], str]) -> None:
@@ -112,11 +115,8 @@ def generate_html_output(
                             replacements[f"<!-- %{item}_{index+1}_{entry_key}% -->"] = (
                                 html_line_breaks(str(entry_value))
                             )
-
-        replacements['"sheetsize_default"'] = '"{}"'.format(
-            metadata.get("template", {}).get("sheetsize", "")
-        )
-        # include quotes so no replacement happens within <style> definition
+                    elif isinstance(entry, (str, int, float)):
+                        pass  # TODO?: replacements[f"<!-- %{item}_{category}% -->"] = html_line_breaks(str(entry))
 
     # perform replacements
     # regex replacement adapted from:


### PR DESCRIPTION
@formatc1702 must must check if this suggested change (placeholder name consistency) is OK, or if it might have some bad side-effects. If there is a good reason to keep this one placeholder very different from the others, then that reason should be explained in a code comment.

A bonus advantage by using the name `<!-- %template_sheetsize% -->`, is that it will be easy to later generalize by letting any string or numeric `metadata.{item}.{key}` entry replace the corresponding `<!-- %{item}_{key}% -->` placeholder.

~TODO: If both PR #371 and this PR is accepted, then the `templates/README.md` file must be updated.~ (it is now updated)

Fixes #377