### PR TITLE
Add non-empty label to avoid over-sized loops

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -281,6 +281,7 @@ class Harness:
                     dot.edge(
                         f"{connector.name}:p{loop[0]}{loop_side}:{loop_dir}",
                         f"{connector.name}:p{loop[1]}{loop_side}:{loop_dir}",
+                        label = " ",  # Work-around to avoid over-sized loops.
                     )
 
         # determine if there are double- or triple-colored wires in the harness;


### PR DESCRIPTION
Work-around to improve the #286 use case.