### PR TITLE
Fix Exception Handling in _get_yaml_data_and_path(...)

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -410,10 +410,11 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if no FileNotFoundError exception happens, get file contents
             yaml_str = open_file_read(yaml_path).read()
         except (FileNotFoundError, OSError, ValueError) as e:
-            # if inp is a long YAML string, Pathlib will raise OSError: [errno.ENAMETOOLONG]
-            # (in Windows, it seems OSError [errno.EINVAL] might be raised in some cases)
-            # when trying to expand and resolve it as a path.
-            # Catch this error, but raise any others
+            # if inp is a long YAML string, Pathlib will raise OSError [errno.ENAMETOOLONG]
+            # in Windows, ValueError or OSError [errno.EINVAL or None] also might be raised
+            # when trying to expand and resolve it as a path (depending on the Python version)
+            # Catch these specific errors, but raise any others
+
             from errno import EINVAL, ENAMETOOLONG
 
             if type(e) is OSError and e.errno not in (EINVAL, ENAMETOOLONG, None):

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -416,7 +416,7 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # Catch this error, but raise any others
             from errno import EINVAL, ENAMETOOLONG
 
-            if type(e) is OSError and e.errno not in (EINVAL, ENAMETOOLONG):
+            if type(e) is OSError and e.errno not in (EINVAL, ENAMETOOLONG, None):
                 raise e
             # file does not exist; assume inp is a YAML string
             yaml_str = inp

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -410,10 +410,12 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             # if no FileNotFoundError exception happens, get file contents
             yaml_str = open_file_read(yaml_path).read()
         except (FileNotFoundError, OSError, ValueError) as e:
-            # if inp is a long YAML string, Pathlib will raise OSError [errno.ENAMETOOLONG]
-            # in Windows, ValueError or OSError [errno.EINVAL or None] also might be raised
-            # when trying to expand and resolve it as a path (depending on the Python version)
-            # Catch these specific errors, but raise any others
+            # if inp is a long YAML string, Pathlib will normally raise
+            # FileNotFoundError or OSError(errno = ENAMETOOLONG) when
+            # trying to expand and resolve it as a path, but in Windows
+            # might ValueError or OSError(errno = EINVAL or None) be raised
+            # instead in some cases (depending on the Python version).
+            # Catch these specific errors, but raise any others.
 
             from errno import EINVAL, ENAMETOOLONG
 

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -409,7 +409,7 @@ def _get_yaml_data_and_path(inp: Union[str, Path, Dict]) -> (Dict, Path):
             yaml_path = Path(inp).expanduser().resolve(strict=True)
             # if no FileNotFoundError exception happens, get file contents
             yaml_str = open_file_read(yaml_path).read()
-        except (FileNotFoundError, OSError) as e:
+        except (FileNotFoundError, OSError, ValueError) as e:
             # if inp is a long YAML string, Pathlib will raise OSError: [errno.ENAMETOOLONG]
             # (in Windows, it seems OSError [errno.EINVAL] might be raised in some cases)
             # when trying to expand and resolve it as a path.


### PR DESCRIPTION
Add ValueError and OSError where `e.errno` is `None` to Exception Handling of `_get_yaml_data_and_path()`


**This PR is amending fixes for the following issues based on #250 and #318.**
- https://github.com/wireviz/WireViz/pull/318#pullrequestreview-1457016602
  describing 80000 character YAML input raising `ValueError`
- https://github.com/wireviz/WireViz/issues/391#issuecomment-2180419249 
  describing `OSError: _getfinalpathname: path too long for Windows` 


```
# if inp is a long YAML string, Pathlib will raise OSError [errno.ENAMETOOLONG]
# in Windows, ValueError or OSError [errno.EINVAL or None] also might be raised
# when trying to expand and resolve it as a path (depending on the Python version)
# Catch these specific errors, but raise any others
```
 
`master` contains #250 from d7d7854bce39881a970b54e3522d9293441c5ce1: Consolidate wireviz.parse() to handle Path, str and Dict as input

https://github.com/wireviz/WireViz/blob/954c4f5f92b1d0531f6af0c318c60786b7906d42/src/wireviz/wireviz.py#L415

`release/v0.4.1-rc` contains #318 at 6f9007f45d48cc65f3469b362976bb53ac1cd7e0: Use portable OS error codes so program doesn't crash

https://github.com/wireviz/WireViz/blob/ba84c54382b540dfa50dcd5e3592917abdbfb1f8/src/wireviz/wireviz.py#L419


Due to the following https://github.com/wireviz/WireViz/pull/246#issuecomment-1206635845, this is a bugfix only, waiting to be resolved by #251. 
> All comments have been addressed inside #251 or are no longer relevant after 251 is applied



_References_
- #365
  - #391
    #392
  - #344
    #346
  - #318
- #190
  #246
- #250
  #251