### PR TITLE
Update deprecated GitHub Actions and add Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -21,7 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools
         pip install .
     - name: Create Examples
       run: PYTHONPATH=$(pwd)/src/wireviz:$PYTHONPATH cd src/wireviz/ && python build_examples.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,12 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +28,7 @@ jobs:
     - name: Upload examples, demos, and tutorials
       uses: actions/upload-artifact@v4
       with:
-        name: examples-and-tutorials-${{ matrix.os }}-${{ matrix.version }}
+        name: examples-and-tutorials-v${{ matrix.python-version }}
         path: |
           examples/
           tutorial/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,3 +31,5 @@ jobs:
         path: |
           examples/
           tutorial/
+        if-no-files-found: error
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,23 +8,24 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools
         pip install .
     - name: Create Examples
-      run: PYTHONPATH=$(pwd)/src:$PYTHONPATH cd src/wireviz/ && python build_examples.py
+      run: PYTHONPATH=$(pwd)/src/wireviz:$PYTHONPATH cd src/wireviz/ && python build_examples.py
     - name: Upload examples, demos, and tutorials
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: examples-and-tutorials
         path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Upload examples, demos, and tutorials
       uses: actions/upload-artifact@v4
       with:
-        name: examples-and-tutorials
+        name: examples-and-tutorials-${{ matrix.os }}-${{ matrix.version }}
         path: |
           examples/
           tutorial/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Graphviz


### PR DESCRIPTION
**Running 6 different Python versions (3.7 to 3.12) in parallel now.** 
NOTE: This is in conflict with #309, but can be resolved easily.

GitHub Actions require an update:
- actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. 
- Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. 
- Updating this comes with a breaking change in upload-artifact@v4:
  **_Uploading to the same named Artifact multiple times._**

> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

**The artifact .zip files therefore have the python version added to their name.**