### PR TITLE
Add support for a custom template directory path

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -666,6 +666,7 @@ class Harness:
         view: bool = False,
         cleanup: bool = True,
         fmt: tuple = ("html", "png", "svg", "tsv"),
+        templatedir: (str, Path) = None,
     ) -> None:
         # graphical output
         graph = self.graph
@@ -697,7 +698,7 @@ class Harness:
             print("CSV output is not yet supported")
         # HTML output
         if "html" in fmt:
-            generate_html_output(filename, bomlist, self.metadata, self.options)
+            generate_html_output(filename, bomlist, self.metadata, self.options, templatedir=templatedir)
         # PDF output
         if "pdf" in fmt:
             # TODO: implement PDF output

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -31,6 +31,7 @@ def parse(
     output_dir: Union[str, Path] = None,
     output_name: Union[None, str] = None,
     image_paths: Union[Path, str, List] = [],
+    template_dir: Union[str, Path] = None,
 ) -> Any:
     """
     This function takes an input, parses it as a WireViz Harness file,
@@ -382,7 +383,7 @@ def parse(
             harness.add_bom_item(line)
 
     if output_formats:
-        harness.output(filename=output_file, fmt=output_formats, view=False)
+        harness.output(filename=output_file, fmt=output_formats, view=False, templatedir=template_dir)
 
     if return_types:
         returns = []

--- a/src/wireviz/wv_cli.py
+++ b/src/wireviz/wv_cli.py
@@ -65,13 +65,20 @@ epilog += ", ".join([f"{key} ({value.upper()})" for key, value in format_codes.i
     help="File name (without extension) to use for output files, if different from input file name.",
 )
 @click.option(
+    "-t",
+    "--template-dir",
+    default=None,
+    type=Path,
+    help="Directory to look into for html template file (optional)",
+)
+@click.option(
     "-V",
     "--version",
     is_flag=True,
     default=False,
     help=f"Output {APP_NAME} version and exit.",
 )
-def wireviz(file, format, prepend, output_dir, output_name, version):
+def wireviz(file, format, prepend, output_dir, output_name, template_dir, version):
     """
     Parses the provided FILE and generates the specified outputs.
     """
@@ -144,6 +151,7 @@ def wireviz(file, format, prepend, output_dir, output_name, version):
             output_dir=_output_dir,
             output_name=_output_name,
             image_paths=list(image_paths),
+            template_dir=template_dir,
         )
 
     print()

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -21,14 +21,23 @@ def generate_html_output(
     bom_list: List[List[str]],
     metadata: Metadata,
     options: Options,
+    templatedir: Union[str, Path],
 ):
+    print("Test")
     # load HTML template
     templatename = metadata.get("template", {}).get("name")
     if templatename:
+        templatedirs = []
+        
+        # if template directory is provided, add it to the lookup paths
+        if templatedir is not None:
+            templatedirs.append(templatedir)
         # if relative path to template was provided, check directory of YAML file first, fall back to built-in template directory
+        templatedirs.extend([Path(filename).parent, Path(__file__).parent / "templates"])
+
         templatefile = smart_file_resolve(
             f"{templatename}.html",
-            [Path(filename).parent, Path(__file__).parent / "templates"],
+            templatedirs,
         )
     else:
         # fall back to built-in simple template if no template was provided


### PR DESCRIPTION
# Issue

I have a custom HTML template file which is shared by multiple cable designs. The path of the template file is not the same for all the cables and therefore I can't copy / paste the headers of my cable definition with the path of the template file.

# Solution

Add a template directory option to the CLI to have a custom template directory lookup path